### PR TITLE
fixing mixed mode stylesheet import

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,7 +17,7 @@
   <link rel="stylesheet" href="/public/css/poole.css">
   <link rel="stylesheet" href="/public/css/syntax.css">
   <link rel="stylesheet" href="/public/css/hyde.css">
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
+  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/public/apple-touch-icon-144-precomposed.png">


### PR DESCRIPTION
Fix error:
```
Mixed Content: The page at 'https://shauvik.com/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface'. This request has been blocked; the content must be served over HTTPS.
```